### PR TITLE
feat(content): add mediaKeys filter to GET /content/last

### DIFF
--- a/src/content/application/content.controller.ts
+++ b/src/content/application/content.controller.ts
@@ -15,6 +15,7 @@ import { ContentService } from './content.service';
 import { ShareableContentResponse } from './dto/shareable-content.dto';
 import { GetAudioContentUrlByIdQuery } from './queries/get-audio-content-url-by-id/get-audio-content-url-by-id.query';
 import { GetLastContentPaginatedQuery } from './queries/get-last-content-paginated/get-last-content-paginated.query';
+import { MediaKeysValueType } from './queries/get-last-content-paginated/media-keys.value-type';
 import { SearchedContentTermValueType } from './queries/get-last-content-paginated/searched-content-term.value-type';
 import { GetShareableContentQuery } from './queries/get-shareable-content/get-shareable-content.query';
 import { GetIdFromContentIdAndKeyQuery } from './queries/get-id-from-content-id-and-media-key/get-id-from-content-id-and-media-key.query';
@@ -34,11 +35,13 @@ export class ContentController {
     @Query('page', ParseIntPipe) page: number,
     @Query('size', ParseIntPipe) size: number,
     @Query('terms') terms?: string,
+    @Query('mediaKeys') mediaKeys?: string,
   ) {
     return this.queryBus.execute(
       new GetLastContentPaginatedQuery(
         new RequestedPageValueType(page, size),
         new SearchedContentTermValueType(terms),
+        new MediaKeysValueType(mediaKeys),
       ),
     );
   }

--- a/src/content/application/queries/get-last-content-paginated/get-last-content-paginated.handler.ts
+++ b/src/content/application/queries/get-last-content-paginated/get-last-content-paginated.handler.ts
@@ -1,6 +1,6 @@
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, ILike, Repository } from 'typeorm';
+import { FindOptionsWhere, ILike, In, Repository } from 'typeorm';
 import { Page } from '../../../../core/page';
 import { Content } from '../../../domain/content.entity';
 import { GetLastContentPaginatedQuery } from './get-last-content-paginated.query';
@@ -14,13 +14,22 @@ export class GetLastContentPaginatedHandler
   ) { }
 
   async execute(query: GetLastContentPaginatedQuery) {
-    const { requestedPage, terms } = query;
+    const { requestedPage, terms, mediaKeys } = query;
 
     let where: FindOptionsWhere<Content> | undefined;
 
     if (terms.isDefined) {
       where = {
         title: ILike(`%${terms.value}%`),
+      };
+    }
+
+    if (mediaKeys.isDefined) {
+      where = {
+        ...where,
+        metaMedia: {
+          key: In(mediaKeys.values),
+        },
       };
     }
 

--- a/src/content/application/queries/get-last-content-paginated/get-last-content-paginated.query.ts
+++ b/src/content/application/queries/get-last-content-paginated/get-last-content-paginated.query.ts
@@ -1,9 +1,11 @@
 import { RequestedPageValueType } from '../../../../core/page-number.value-type';
+import { MediaKeysValueType } from './media-keys.value-type';
 import { SearchedContentTermValueType } from './searched-content-term.value-type';
 
 export class GetLastContentPaginatedQuery {
   constructor(
     public readonly requestedPage: RequestedPageValueType,
-    public terms: SearchedContentTermValueType,
+    public readonly terms: SearchedContentTermValueType,
+    public readonly mediaKeys: MediaKeysValueType,
   ) {}
 }

--- a/src/content/application/queries/get-last-content-paginated/media-keys.value-type.ts
+++ b/src/content/application/queries/get-last-content-paginated/media-keys.value-type.ts
@@ -1,0 +1,17 @@
+export class MediaKeysValueType {
+  get isDefined(): boolean {
+    return this.keys !== undefined && this.keys !== null && this.keys !== '';
+  }
+
+  get values(): string[] {
+    if (!this.isDefined) {
+      return [];
+    }
+    return this.keys
+      .split(',')
+      .map((key) => key.trim())
+      .filter((key) => key !== '');
+  }
+
+  constructor(private readonly keys?: string) {}
+}


### PR DESCRIPTION
## Summary
- Add optional `mediaKeys` query parameter to filter content by media source
- Create `MediaKeysValueType` to handle comma-separated media keys
- Update handler to filter using TypeORM `In` operator

Part of #157 (hugoblanc/Athena)

## Test plan
- [ ] Call `GET /content/last?page=1&size=10` - should return all content (no filter)
- [ ] Call `GET /content/last?page=1&size=10&mediaKeys=blast,lmm` - should return only content from Blast and Le Monde Moderne

🤖 Generated with [Claude Code](https://claude.com/claude-code)